### PR TITLE
Fix global-shortcut break other apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,21 @@ const isOSX = process.platform === 'darwin';
 
 module.exports = function () {
 	app.on('ready', function () {
-		globalShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
-		globalShortcut.register('F12', devTools);
+		app.on('browser-window-focus', function() {
+			globalShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
+			globalShortcut.register('F12', devTools);
 
-		globalShortcut.register('CmdOrCtrl+R', refresh);
-		globalShortcut.register('F5', refresh);
+			globalShortcut.register('CmdOrCtrl+R', refresh);
+			globalShortcut.register('F5', refresh);
+		});
+		
+		app.on('browser-window-blur', function() {
+			globalShortcut.unregister(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I');
+			globalShortcut.unregister('F12');
+			
+			globalShortcut.unregister('CmdOrCtrl+R');
+			globalShortcut.unregister('F5');
+		});
 
 		function devTools() {
 			var win = BrowserWindow.getFocusedWindow();


### PR DESCRIPTION
register `global-shortcut` will break other applications' shortcut, so change to register when `browser-window-focus` and unregister when `browser-window-blur`.

see: https://github.com/chentsulin/electron-react-boilerplate/issues/42