### PR TITLE
implemented inspect element context menu as per #9

### DIFF
--- a/debug-context-menu.js
+++ b/debug-context-menu.js
@@ -1,0 +1,40 @@
+'use strict';
+const remote = require('remote');
+const Menu = remote.require('menu');
+const MenuItem = remote.require('menu-item');
+const BrowserWindow = remote.require('browser-window');
+
+let rightClickPosition = null;
+
+const menu = buildDebugMenu();
+
+module.exports = {
+	install: install,
+	uninstall: uninstall
+};
+
+function buildDebugMenu() {
+	const mnu = new Menu();
+	mnu.append(new MenuItem({
+		label: 'Inspect element',
+		click: () => {
+			const currentWindow = BrowserWindow.getFocusedWindow();
+			currentWindow.inspectElement(rightClickPosition.x, rightClickPosition.y);
+		}
+	}));
+	return mnu;
+}
+
+function install() {
+	global.window.addEventListener('contextmenu', onContextMenu, false);
+}
+
+function uninstall() {
+	global.window.removeEventListener('contextmenu', onContextMenu, false);
+}
+
+function onContextMenu(e) {
+	e.preventDefault();
+	rightClickPosition = {x: e.x, y: e.y};
+	menu.popup();
+}

--- a/index.js
+++ b/index.js
@@ -20,22 +20,49 @@ function refresh() {
 	}
 }
 
+function activateDebugContextMenu(e) {
+	const webContents = e.sender;
+	webContents.executeJavaScript(`require('${__dirname}/debug-context-menu').install();`);
+}
+
+function deactivateDebugContextMenu(e) {
+	const webContents = e.sender;
+	webContents.executeJavaScript(`require('${__dirname}/debug-context-menu').uninstall();`);
+}
+
+function installDebugContextMenu(win) {
+	win.webContents.on('devtools-opened', activateDebugContextMenu);
+	win.webContents.on('devtools-closed', deactivateDebugContextMenu);
+	if (win.webContents.isDevToolsOpened()) {
+		activateDebugContextMenu({sender: win.webContents});
+	}
+}
+
+function uninstallDebugContextMenu(win) {
+	win.webContents.removeListener('devtools-opened', activateDebugContextMenu);
+	win.webContents.removeListener('devtools-closed', deactivateDebugContextMenu);
+}
+
 module.exports = function () {
 	app.on('ready', function () {
-		app.on('browser-window-focus', function () {
+		app.on('browser-window-focus', function (e, win) {
 			globalShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 			globalShortcut.register('F12', devTools);
 
 			globalShortcut.register('CmdOrCtrl+R', refresh);
 			globalShortcut.register('F5', refresh);
+
+			installDebugContextMenu(win);
 		});
 
-		app.on('browser-window-blur', function () {
+		app.on('browser-window-blur', function (e, win) {
 			globalShortcut.unregister(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I');
 			globalShortcut.unregister('F12');
 
 			globalShortcut.unregister('CmdOrCtrl+R');
 			globalShortcut.unregister('F5');
+
+			uninstallDebugContextMenu(win);
 		});
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,11 @@ Force reload the window.
 - Linux: <kbd>Ctrl</kbd> <kbd>R</kbd> or <kbd>F5</kbd>
 - Windows: <kbd>Ctrl</kbd> <kbd>R</kbd> or <kbd>F5</kbd>
 
+### Inspect element
+
+Right click on a HTML element to inspect it on Dev Tools like
+in Chromium. Works only when Dev Tools is already open.
+
 
 ## Install
 


### PR DESCRIPTION
I created a separate file `debug-context-menu.js` that handles all operations that occurs  in renderer process, to be able to require it in renderer via `executeJavaScript`.

I hope you're ok with this, otherwise we have to put all the code inside a string template (I think this is ugly)...

I also wrote a `test.js` file that open two BW on google and github, just to test the stuff:
I didn't include this in PR to avoid polluting the package. Do you prefere to include it?


test.js:
```js
'use strict';
require('.')();

var app = require('app');
var BrowserWindow = require('browser-window');

app.on('ready', function () {
	var win = new BrowserWindow({width: 800, height: 600});
	win.loadUrl('https://github.com');
	win.show();

	var win2 = new BrowserWindow({width: 800, height: 600});
	win2.loadUrl('https://google.com');
	win2.show();
});
```



