### PR TITLE
saved require to window.__electron_debug.require on win creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ function refresh() {
 
 function activateDebugContextMenu(e) {
 	const webContents = e.sender;
-	webContents.executeJavaScript(`require('${__dirname}/context-menu').install();`);
+	webContents.executeJavaScript(`window.__electron_debug.require('${__dirname}/context-menu').install();`);
 }
 
 function deactivateDebugContextMenu(e) {
 	const webContents = e.sender;
-	webContents.executeJavaScript(`require('${__dirname}/context-menu').uninstall();`);
+	webContents.executeJavaScript(`window.__electron_debug.require('${__dirname}/context-menu').uninstall();`);
 }
 
 function installDebugContextMenu(win) {
@@ -45,25 +45,27 @@ function uninstallDebugContextMenu(win) {
 }
 
 module.exports = () => {
-	app.on('ready', () => {
-		app.on('browser-window-focus', (e, win) => {
-			globalShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
-			globalShortcut.register('F12', devTools);
+	app.on('browser-window-created', (e, win) => {
+		win.webContents.executeJavaScript('window.__electron_debug = {require: window.require};');
+	});
 
-			globalShortcut.register('CmdOrCtrl+R', refresh);
-			globalShortcut.register('F5', refresh);
+	app.on('browser-window-focus', (e, win) => {
+		globalShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
+		globalShortcut.register('F12', devTools);
 
-			installDebugContextMenu(win);
-		});
+		globalShortcut.register('CmdOrCtrl+R', refresh);
+		globalShortcut.register('F5', refresh);
 
-		app.on('browser-window-blur', (e, win) => {
-			globalShortcut.unregister(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I');
-			globalShortcut.unregister('F12');
+		installDebugContextMenu(win);
+	});
 
-			globalShortcut.unregister('CmdOrCtrl+R');
-			globalShortcut.unregister('F5');
+	app.on('browser-window-blur', (e, win) => {
+		globalShortcut.unregister(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I');
+		globalShortcut.unregister('F12');
 
-			uninstallDebugContextMenu(win);
-		});
+		globalShortcut.unregister('CmdOrCtrl+R');
+		globalShortcut.unregister('F5');
+
+		uninstallDebugContextMenu(win);
 	});
 };


### PR DESCRIPTION
I saved require reference inside window. Fixes #13. 
I choose not to save `module` global since it is not used... it can be easy to add it if needed in future...

Also, I removed the `ready` handler at line 48. Since no browser window could be created before the app is ready, it appear to be redundant. Do you agree, or am I missing something here?