### PR TITLE
Added require('browser-window')

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ $ npm install --save electron-debug
 
 ```js
 const app = require('app');
+const BrowserWindow = require('browser-window');
 
 require('electron-debug')({
 	showDevTools: true


### PR DESCRIPTION
Since the example include require('app'), it's best to also require b-w, to give a working example