### PR TITLE
bump electron-prebuilt dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
-const app = require('app');
-const BrowserWindow = require('browser-window');
+const electron = require('electron');
+const app = electron.app;
+const BrowserWindow = electron.BrowserWindow;
 const localShortcut = require('electron-localshortcut');
 const isOSX = process.platform === 'darwin';
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "electron-localshortcut": "^0.4.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.34.3",
+    "electron-prebuilt": "^0.35.0",
     "xo": "*"
   },
   "xo": {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,6 @@ const BrowserWindow = require('browser-window');
 require('.')({showDevTools: true});
 
 app.on('ready', () => {
-	(new BrowserWindow({show: true})).loadUrl('https://github.com');
-	(new BrowserWindow({show: true})).loadUrl('https://google.com');
+	(new BrowserWindow({show: true})).loadURL('https://github.com');
+	(new BrowserWindow({show: true})).loadURL('https://google.com');
 });

--- a/test.js
+++ b/test.js
@@ -1,10 +1,17 @@
 'use strict';
-const app = require('app');
-const BrowserWindow = require('browser-window');
+const electron = require('electron');
+const app = electron.app;
+const BrowserWindow = electron.BrowserWindow;
 
 require('.')({showDevTools: true});
 
+function load(url) {
+	const win = new BrowserWindow({show: true});
+	win.loadURL(url);
+	win.setMenu(null);
+}
+
 app.on('ready', () => {
-	(new BrowserWindow({show: true})).loadURL('https://github.com');
-	(new BrowserWindow({show: true})).loadURL('https://google.com');
+	load('https://github.com');
+	load('https://google.com');
 });


### PR DESCRIPTION
I also renamed deprecated method `loadUrl` to `loadURL` in test.js.
How do you think to deal with [other deprecation](https://github.com/atom/electron/releases/tag/v0.35.0) electron introduce in release 35? Do you prefer to keep compatibily with previous releases or stay up-to-date with new `electron` modules naming?