### PR TITLE
reloadIgnoringCache is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function refresh() {
 	const win = BrowserWindow.getFocusedWindow();
 
 	if (win) {
-		win.reloadIgnoringCache();
+		win.webContents.reloadIgnoringCache();
 	}
 }
 


### PR DESCRIPTION
reloadIgnoringCache is deprecated in electron v.035