### PR TITLE
Extend showDevTools option to allow different DevTools states

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,15 @@ function devTools(win) {
 	}
 }
 
+function openDevTools(win, showDevTools) {
+	win = win || BrowserWindow.getFocusedWindow();
+
+	if (win) {
+		const mode = showDevTools !== true ? showDevTools : undefined;
+		win.webContents.openDevTools({mode});
+	}
+}
+
 function refresh(win) {
 	win = win || BrowserWindow.getFocusedWindow();
 
@@ -33,8 +42,9 @@ module.exports = opts => {
 	}
 
 	app.on('browser-window-created', (e, win) => {
+
 		if (opts.showDevTools) {
-			devTools(win);
+			openDevTools(win, opts.showDevTools);
 		}
 	});
 
@@ -49,3 +59,4 @@ module.exports = opts => {
 
 module.exports.refresh = refresh;
 module.exports.devTools = devTools;
+module.exports.openDevTools = openDevTools;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron-localshortcut": "^0.6.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.37.7",
+    "electron-prebuilt": "0.37.7",
     "xo": "*"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron-localshortcut": "^0.6.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "0.37.2",
+    "electron-prebuilt": "^0.37.7",
     "xo": "*"
   },
   "xo": {

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,15 @@ Default: `false`
 
 Show DevTools on each created `BrowserWindow`.
 
+Can take one of the `mode` values allowed by [webContents.openDevTools](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#webcontentsopendevtoolsoptions) method to specify DevTools state:
+
+ * "right"
+ * "bottom"
+ * "undocked"
+ * "detach"
+ * true - last used DevTools dock state.
+
+
 ### devTools([window])
 
 Toggle DevTools for the specified `BrowserWindow` instance or the focused one.
@@ -87,6 +96,25 @@ Reload the specified `BrowserWindow` instance or the focused one.
 
 Type: `BrowserWindow`<br>
 Default: the focused `BrowserWindow`
+
+### openDevTools([window], [showDevTools])
+
+Open DevTools for the specified `BrowserWindow` instance or the focused one.
+
+#### window
+
+Type: `BrowserWindow`<br>
+Default: the focused `BrowserWindow`
+
+#### showDevTools
+
+The DevTools state to use. Can take one of the `mode` values allowed by [webContents.openDevTools](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#webcontentsopendevtoolsoptions) method:
+
+ * "right"
+ * "bottom"
+ * "undocked"
+ * "detach"
+ * true - last used DevTools dock state.
 
 
 ## Related


### PR DESCRIPTION
I get some doubt here:

* Do you think it could be useful to add shortcuts for the different modes? I think too many shortcuts could bring some confusion...

* Do you know what is the difference between "undocked" and "detached"? Seems to have same effect...