### PR TITLE
add extensions option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,11 +33,12 @@ function refresh(win) {
 
 module.exports = opts => {
 	opts = Object.assign({
-		enabled: null,
-		showDevTools: false
+		enabled: true,
+		showDevTools: false,
+		extensions: {},
 	}, opts);
 
-	if (opts.enabled === false || (opts.enabled === null && !isDev)) {
+	if (!opts.enabled || !isDev) {
 		return;
 	}
 
@@ -48,11 +49,10 @@ module.exports = opts => {
 	});
 
 	app.on('ready', () => {
-		// activate devtron for the user if they have it installed
-		try {
-			BrowserWindow.addDevToolsExtension(require('devtron').path);
-		} catch (err) {}
-
+		Object.keys(opts.extensions).forEach((name) => {
+			BrowserWindow.removeDevToolsExtension(name);
+			BrowserWindow.addDevToolsExtension(opts.extensions[name]);
+		});
 		localShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 		localShortcut.register('F12', devTools);
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = opts => {
 	opts = Object.assign({
 		enabled: true,
 		showDevTools: false,
-		extensions: {},
+		extensions: {}
 	}, opts);
 
 	if (!opts.enabled || !isDev) {
@@ -49,7 +49,7 @@ module.exports = opts => {
 	});
 
 	app.on('ready', () => {
-		Object.keys(opts.extensions).forEach((name) => {
+		Object.keys(opts.extensions).forEach(name => {
 			BrowserWindow.removeDevToolsExtension(name);
 			if (opts.extensions[name]) {
 				BrowserWindow.addDevToolsExtension(opts.extensions[name]);

--- a/index.js
+++ b/index.js
@@ -49,12 +49,14 @@ module.exports = opts => {
 	});
 
 	app.on('ready', () => {
-		Object.keys(opts.extensions).forEach(name => {
-			BrowserWindow.removeDevToolsExtension(name);
-			if (opts.extensions[name]) {
-				BrowserWindow.addDevToolsExtension(opts.extensions[name]);
-			}
-		});
+		if (isDev) {
+			Object.keys(opts.extensions).forEach(name => {
+				BrowserWindow.removeDevToolsExtension(name);
+				if (opts.extensions[name]) {
+					BrowserWindow.addDevToolsExtension(opts.extensions[name]);
+				}
+			});
+		}
 		localShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 		localShortcut.register('F12', devTools);
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,9 @@ module.exports = opts => {
 	app.on('ready', () => {
 		Object.keys(opts.extensions).forEach((name) => {
 			BrowserWindow.removeDevToolsExtension(name);
-			BrowserWindow.addDevToolsExtension(opts.extensions[name]);
+			if (opts.extensions[name]) {
+				BrowserWindow.addDevToolsExtension(opts.extensions[name]);
+			}
 		});
 		localShortcut.register(isOSX ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 		localShortcut.register('F12', devTools);

--- a/index.js
+++ b/index.js
@@ -33,12 +33,12 @@ function refresh(win) {
 
 module.exports = opts => {
 	opts = Object.assign({
-		enabled: true,
+		enabled: null,
 		showDevTools: false,
 		extensions: {}
 	}, opts);
 
-	if (!opts.enabled || !isDev) {
+	if (opts.enabled === false || (opts.enabled === null && !isDev)) {
 		return;
 	}
 


### PR DESCRIPTION
Add extensions option for more electron extension.

Now it can be initialized like this:

```
require('electron-debug')({
  showDevTools: true,
  extensions: {
    devtron: path.resolve(__dirname, '../node_modules/devtron'),
    vue-devtools: path.resolve(__dirname, '../node_modules/vue-devtools'),
  },
})
```

So can use Chrome's extension from disk path.