### PR TITLE
Check if devtron extension is already added before adding again

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,9 +48,15 @@ module.exports = opts => {
 	});
 
 	app.on('ready', () => {
-		// activate devtron for the user if they have it installed
+		// activate devtron for the user if they have it installed and it's not already added
 		try {
-			BrowserWindow.addDevToolsExtension(require('devtron').path);
+			const devtronAlreadyAdded =
+				(BrowserWindow.getDevToolsExtensions
+				&& BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron'));
+
+			if (!devtronAlreadyAdded) {
+				BrowserWindow.addDevToolsExtension(require('devtron').path);
+			}
 		} catch (err) {}
 
 		localShortcut.register(isMacOS ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ module.exports = opts => {
 		// activate devtron for the user if they have it installed and it's not already added
 		try {
 			const devtronAlreadyAdded =
-				(BrowserWindow.getDevToolsExtensions
-				&& BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron'));
+				BrowserWindow.getDevToolsExtensions &&
+				BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron');
 
 			if (!devtronAlreadyAdded) {
 				BrowserWindow.addDevToolsExtension(require('devtron').path);


### PR DESCRIPTION
Electron v1.2.3 added the ability to check if devtool extensions are already added (https://github.com/electron/electron/pull/5965)

This change prevents the following from being printed to the console on every run after initially adding devtron:
```
Attempted to load extension "devtron", but extension was already loaded!
```

More info also here: https://github.com/electron/electron/issues/5960