### PR TITLE
enable element inspector with a keyboard shortcut

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,13 +74,7 @@ module.exports = opts => {
 			}
 		} catch (err) {}
 
-		if (isMacOS) {
-			localShortcut.register('Cmd+Shift+C', inspectElements);
-			localShortcut.register('Cmd+Alt+C', inspectElements);
-		} else {
-			localShortcut.register('Ctrl+Shift+C', inspectElements);
-		}
-
+		localShortcut.register('CmdOrCtrl+Shift+C', inspectElements);
 		localShortcut.register(isMacOS ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 		localShortcut.register('F12', devTools);
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function inspectElements() {
 	const win = BrowserWindow.getFocusedWindow();
 	const inspect = () => {
 		win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
-	}
+	};
 
 	if (win) {
 		if (win.webContents.isDevToolsOpened()) {

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ function inspectElements() {
 		if (win.webContents.isDevToolsOpened()) {
 			win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
 		} else {
-			win.webContents.on('devtools-opened', function () {
+			win.webContents.on('devtools-opened', () => {
 				win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
-			})
+			});
 			win.openDevTools();
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -32,6 +32,21 @@ function refresh(win) {
 	}
 }
 
+function inspectElements() {
+	const win = BrowserWindow.getFocusedWindow();
+
+	if (win) {
+		if (win.webContents.isDevToolsOpened()) {
+			win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
+		} else {
+			win.webContents.on('devtools-opened', function () {
+				win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
+			})
+			win.openDevTools();
+		}
+	}
+}
+
 module.exports = opts => {
 	opts = Object.assign({
 		enabled: null,
@@ -58,6 +73,13 @@ module.exports = opts => {
 				BrowserWindow.addDevToolsExtension(require('devtron').path);
 			}
 		} catch (err) {}
+
+		if (isMacOS) {
+			localShortcut.register('Cmd+Shift+C', inspectElements);
+			localShortcut.register('Cmd+Alt+C', inspectElements);
+		} else {
+			localShortcut.register('Ctrl+Shift+C', inspectElements);
+		}
 
 		localShortcut.register(isMacOS ? 'Cmd+Alt+I' : 'Ctrl+Shift+I', devTools);
 		localShortcut.register('F12', devTools);

--- a/index.js
+++ b/index.js
@@ -34,14 +34,15 @@ function refresh(win) {
 
 function inspectElements() {
 	const win = BrowserWindow.getFocusedWindow();
+	const inspect = () => {
+		win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
+	}
 
 	if (win) {
 		if (win.webContents.isDevToolsOpened()) {
-			win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
+			inspect();
 		} else {
-			win.webContents.on('devtools-opened', () => {
-				win.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()');
-			});
+			win.webContents.on('devtools-opened', inspect);
 			win.openDevTools();
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,14 @@ Force reload the window.
 - Linux: <kbd>Ctrl</kbd> <kbd>R</kbd> or <kbd>F5</kbd>
 - Windows: <kbd>Ctrl</kbd> <kbd>R</kbd> or <kbd>F5</kbd>
 
+### Element Inspector
+
+Open DevTools and focus the Element Inspector tool.
+
+- macOS: <kbd>Cmd</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
+- Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
+- Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
+
 ### Activates Devtron
 
 [Devtron](http://electron.atom.io/devtron/) is the official Electron DevTools extension.


### PR DESCRIPTION
![screen shot 2016-09-08 at 10 22 28 pm](https://cloud.githubusercontent.com/assets/2289/18376321/04fb1146-7613-11e6-89e6-8df1c6e64037.png)

This PR allows "inspect element mode" to be enabled with a keyboard shortcut. The behavior matches that of the Chrome browser:

- If DevTools is already open, the shortcut toggles "inspect element mode"
- If DevTools is _not_ open, it is toggled open and initialized in "inspect element mode"
- The keyboard shortcuts are [identical to Chrome](https://developers.google.com/web/tools/chrome-devtools/inspect-styles/shortcuts). Note however that <kbd>Cmd</kbd><kbd>Alt</kbd><kbd>C</kbd> shortcut for MacOS is not documented but is supported by Chrome.

Fixes #43