### PR TITLE
Add screenshot feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const isDev = require('electron-is-dev');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const dialog = electron.dialog;
+const clipboard = electron.clipboard;
 const isMacOS = process.platform === 'darwin';
 
 function devTools(win) {
@@ -53,20 +54,28 @@ function inspectElements() {
 function screenshot(win) {
 	win = win || BrowserWindow.getFocusedWindow();
 	win.capturePage(image => {
-		dialog.showSaveDialog(win, {filters: [{name: 'Images', extensions: ['jpg', 'png']}]}, filename => {
-			const filetype = filename.split('.').pop();
-			let imageBuffer;
+		dialog.showMessageBox(win, {type: 'question', buttons: ['Cancel', 'Copy to clipboard', 'Save to file'], message: 'What would you like to do with this image?', cancelId: 0}, response => {
+			if (response === 1) {
+				clipboard.writeImage(image);
+			} else if (response === 2) {
+				dialog.showSaveDialog(win, {filters: [{name: 'Images', extensions: ['jpg', 'png']}]}, filename => {
+					if (filename) {
+						const filetype = filename.split('.').pop();
+						let imageBuffer;
 
-			if (filetype === 'png') {
-				imageBuffer = image.toPNG();
-			} else if (filetype === 'jpg') {
-				imageBuffer = image.toJPEG(100);
-			}
+						if (filetype === 'png') {
+							imageBuffer = image.toPNG();
+						} else if (filetype === 'jpg') {
+							imageBuffer = image.toJPEG(100);
+						}
 
-			if (imageBuffer) {
-				fs.writeFile(filename, imageBuffer, err => {
-					if (err) {
-						throw err;
+						if (imageBuffer) {
+							fs.writeFile(filename, imageBuffer, err => {
+								if (err) {
+									throw err;
+								}
+							});
+						}
 					}
 				});
 			}
@@ -108,7 +117,7 @@ module.exports = opts => {
 		localShortcut.register('CmdOrCtrl+R', refresh);
 		localShortcut.register('F5', refresh);
 
-		localShortcut.register('CmdOrCtrl+Shift+S', screenshot);
+		localShortcut.register(isMacOS ? 'Cmd+Alt+3' : 'Ctrl+PrintScreen', screenshot);
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict';
 const electron = require('electron');
+const fs = require('fs');
 const localShortcut = require('electron-localshortcut');
 const isDev = require('electron-is-dev');
 
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
+const dialog = electron.dialog;
 const isMacOS = process.platform === 'darwin';
 
 function devTools(win) {
@@ -48,6 +50,30 @@ function inspectElements() {
 	}
 }
 
+function screenshot(win) {
+	win = win || BrowserWindow.getFocusedWindow();
+	win.capturePage(image => {
+		dialog.showSaveDialog(win, {filters: [{name: 'Images', extensions: ['jpg', 'png']}]}, filename => {
+			const filetype = filename.split('.').pop();
+			let imageBuffer;
+
+			if (filetype === 'png') {
+				imageBuffer = image.toPNG();
+			} else if (filetype === 'jpg') {
+				imageBuffer = image.toJPEG(100);
+			}
+
+			if (imageBuffer) {
+				fs.writeFile(filename, imageBuffer, err => {
+					if (err) {
+						throw err;
+					}
+				});
+			}
+		});
+	});
+}
+
 module.exports = opts => {
 	opts = Object.assign({
 		enabled: null,
@@ -81,6 +107,8 @@ module.exports = opts => {
 
 		localShortcut.register('CmdOrCtrl+R', refresh);
 		localShortcut.register('F5', refresh);
+
+		localShortcut.register('CmdOrCtrl+Shift+S', screenshot);
 	});
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-debug",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Adds useful debug features to your Electron app",
   "license": "MIT",
   "repository": "sindresorhus/electron-debug",

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,9 @@ Open DevTools and focus the Element Inspector tool.
 
 Capture screenshot of the window.
 
-- macOS: <kbd>Cmd</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
-- Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
-- Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
+- macOS: <kbd>Cmd</kbd> <kbd>Alt</kbd> <kbd>3</kbd>
+- Linux: <kbd>Ctrl</kbd> <kbd>PrintScreen</kbd>
+- Windows: <kbd>Ctrl</kbd> <kbd>PrintScreen</kbd>
 
 ### Activates Devtron
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,14 @@ Open DevTools and focus the Element Inspector tool.
 - Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
 - Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>C</kbd>
 
+### Capture Screenshot
+
+Capture screenshot of the window.
+
+- macOS: <kbd>Cmd</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
+- Linux: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
+- Windows: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>
+
 ### Activates Devtron
 
 [Devtron](http://electron.atom.io/devtron/) is the official Electron DevTools extension.


### PR DESCRIPTION
Added the ability to take a screenshot of the electron window, using the shortcut <kbd>CmdOrCtrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>

This is just the shortcut I chose, it's totally up for debate. I also incremented the version to 1.2.0.