### PR TITLE
Bump electron-localshortcut version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "electron-is-dev": "^0.1.0",
-    "electron-localshortcut": "^0.6.0"
+    "electron-localshortcut": "^2.0.0"
   },
   "devDependencies": {
     "devtron": "^1.1.0",


### PR DESCRIPTION
This PR upgrade the dependency on `electron-localshortcut` to ver 2.0.0.
This should solve caprine issue https://github.com/sindresorhus/caprine/issues/202. 
