### PR TITLE
bump electron-is-dev to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "development"
   ],
   "dependencies": {
-    "electron-is-dev": "^0.1.0",
+    "electron-is-dev": "^0.2.0",
     "electron-localshortcut": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello! 👋 

This PR bumps `electron-is-dev` to `0.2.0`. This is mainly to be able to explicitly set `ELECTRON_IS_DEV` to false to disable electron-debug for production-like testing.

See https://github.com/sindresorhus/electron-is-dev/pull/8 for reference.