### PR TITLE
Introduce pre-release version of electron-localshortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"electron-is-dev": "^0.3.0",
-		"electron-localshortcut": "^2.0.0"
+		"electron-localshortcut": "^3.0.0"
 	},
 	"devDependencies": {
 		"devtron": "^1.1.0",


### PR DESCRIPTION

With this PR I introduced dependency on a pre-release version of electron-localshortcut that implement DOM event based shortcuts management.

This version should solve all the problem we had with windows lifecycle management.

The new version is still lacking some implementation, but the part used by `electron-debug` (and `Caprine` btw) is done.

It could be useful to have someone other test this PR (I tested on Ubuntu 17) and seems to work just fine.





