### PR TITLE
fixe #67  by setting default value as previous

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {BrowserWindow} from 'electron';
+import { BrowserWindow } from 'electron';
 
 declare namespace electronDebug {
 	interface Options {
@@ -17,14 +17,14 @@ declare namespace electronDebug {
 		/**
 		The dock state to open DevTools in.
 
-		@default 'undocked'
+		@default 'previous'
 		*/
 		readonly devToolsMode?:
-			| 'undocked'
-			| 'right'
-			| 'bottom'
-			| 'previous'
-			| 'detach';
+		| 'undocked'
+		| 'right'
+		| 'bottom'
+		| 'previous'
+		| 'detach';
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {app, BrowserWindow} = require('electron');
+const { app, BrowserWindow } = require('electron');
 const localShortcut = require('electron-localshortcut');
 const isDev = require('electron-is-dev');
 
@@ -9,7 +9,7 @@ const devToolsOptions = {};
 
 function toggleDevTools(win = BrowserWindow.getFocusedWindow()) {
 	if (win) {
-		const {webContents} = win;
+		const { webContents } = win;
 		if (webContents.isDevToolsOpened()) {
 			webContents.closeDevTools();
 		} else {
@@ -62,14 +62,14 @@ const addExtensionIfInstalled = (name, getPath) => {
 		if (!isExtensionInstalled(name)) {
 			BrowserWindow.addDevToolsExtension(getPath(name));
 		}
-	} catch (_) {}
+	} catch (_) { }
 };
 
 module.exports = options => {
 	options = {
 		isEnabled: null,
 		showDevTools: true,
-		devToolsMode: 'undocked',
+		devToolsMode: 'previous',
 		...options
 	};
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const { app, BrowserWindow } = require('electron');
+const {app, BrowserWindow} = require('electron');
 const localShortcut = require('electron-localshortcut');
 const isDev = require('electron-is-dev');
 
@@ -9,7 +9,7 @@ const devToolsOptions = {};
 
 function toggleDevTools(win = BrowserWindow.getFocusedWindow()) {
 	if (win) {
-		const { webContents } = win;
+		const {webContents} = win;
 		if (webContents.isDevToolsOpened()) {
 			webContents.closeDevTools();
 		} else {

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Show DevTools on each created `BrowserWindow`.
 ##### devToolsMode
 
 Type: `string`<br>
-Default: `'undocked'`<br>
+Default: `'previous'`<br>
 Values: `'undocked'` `'right'` `'bottom'` `'previous'` `'detach'`
 
 The dock state to open DevTools in.


### PR DESCRIPTION
This will fix #67.

Somewhere between 1.5 and 2.0 versions, default option is added as `undocked`. 

Changed that default value to `previous` this will remember users last docked position and uses that to dock devtools.

![dock-position](https://user-images.githubusercontent.com/6153816/59625528-27f41280-9157-11e9-889b-22fa4fcf2557.gif)




