### PR TITLE
Correctly remember the last docking position

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace electronDebug {
 		/**
 		The dock state to open DevTools in.
 
-		@default 'undocked'
+		@default 'previous'
 		*/
 		readonly devToolsMode?:
 			| 'undocked'

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = options => {
 	options = {
 		isEnabled: null,
 		showDevTools: true,
-		devToolsMode: 'undocked',
+		devToolsMode: 'previous',
 		...options
 	};
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Show DevTools on each created `BrowserWindow`.
 ##### devToolsMode
 
 Type: `string`<br>
-Default: `'undocked'`<br>
+Default: `'previous'`<br>
 Values: `'undocked'` `'right'` `'bottom'` `'previous'` `'detach'`
 
 The dock state to open DevTools in.


### PR DESCRIPTION
This will fix #67.

Somewhere between 1.5 and 2.0 versions, default option is added as `undocked`. 

Changed that default value to `previous` this will remember users last docked position and uses that to dock devtools.

![dock-position](https://user-images.githubusercontent.com/6153816/59625528-27f41280-9157-11e9-889b-22fa4fcf2557.gif)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#67: v2.0 doesn't remember the docking position of the dev tools](https://issuehunt.io/repos/36633489/issues/67)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->