### PR TITLE
Fix TypeScript exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,11 +57,11 @@ Toggle DevTools for the specified `BrowserWindow` instance or the focused one.
 
 @param window - Default: `BrowserWindow.getFocusedWindow()`
 */
-export function developmentTools(window?: BrowserWindow): void;
+export function devTools(window?: BrowserWindow): void;
 
 /**
 Open DevTools for the specified `BrowserWindow` instance or the focused one.
 
 @param window - Default: `BrowserWindow.getFocusedWindow()`
 */
-export function openDevelopmentTools(window?: BrowserWindow): void;
+export function openDevTools(window?: BrowserWindow): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ Toggle DevTools for the specified `BrowserWindow` instance or the focused one.
 
 @param window - Default: `BrowserWindow.getFocusedWindow()`
 */
+// eslint-disable-next-line unicorn/prevent-abbreviations
 export function devTools(window?: BrowserWindow): void;
 
 /**
@@ -64,4 +65,5 @@ Open DevTools for the specified `BrowserWindow` instance or the focused one.
 
 @param window - Default: `BrowserWindow.getFocusedWindow()`
 */
+// eslint-disable-next-line unicorn/prevent-abbreviations
 export function openDevTools(window?: BrowserWindow): void;


### PR DESCRIPTION
Some functions declared in `index.d.ts` didn't match the names that were actually being exported in `index.js`.