### PR TITLE
Add options.windowSelector

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,20 +29,19 @@ export type Options = {
 	/**
 	Specify customized options for each window.
 
-	@param window Window to apply the filter or new options to
-	@returns
-	- `true`: To enable `debug` with the global options for the given `window`.
-  - `false`: Disable `debug` for the given `window` (same as returning `{ isEnabled: false }`).
-  - `Partial<Options>`: Object to extend and/or override the global options just for the given `window`.
+	The accepted function receives the window to apply the filter or new options to.
+	It must return one of these values:
 
-	@default `() => true`
+	- `true`: To enable debug with the global options for the given window.
+	- `false`: Disable debug for the given window (same as returning { isEnabled: false }).
+	- `Partial<Options>`: Object to extend and/or override the global options just for the given window.
 
+	@default () => true
 	@example
 	```
 	import debug from 'electron-debug';
-
 	debug({
-	  windowSelector: (window) => window.title !== 'Debug tools',
+		windowSelector: (window) => window.title !== 'Debug tools',
 	});
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export type Options = {
 	*/
 	readonly devToolsMode?:
 	| 'undocked'
+	| 'left'
 	| 'right'
 	| 'bottom'
 	| 'previous'

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,17 @@ export type Options = {
 	| 'bottom'
 	| 'previous'
 	| 'detach';
+
+	/**
+	Allows to select windows to apply the debug options to.
+	Accepts a function to filter each window and returns:
+	- `true` to apply the given options
+	- `false` to skip the window (not apply debug)
+	- `Options` to override the global options
+
+	@default `() => true`
+	*/
+	windowSelector?: (window: Readonly<BrowserWindow>) => boolean | Partial<Options>;
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,15 +33,16 @@ export type Options = {
 	It must return one of these values:
 
 	- `true`: To enable debug with the global options for the given window.
-	- `false`: Disable debug for the given window (same as returning { isEnabled: false }).
-	- `Partial<Options>`: Object to extend and/or override the global options just for the given window.
+	- `false`: Disable debug for the given window (same as returning `{isEnabled: false}`).
+	- `Partial<Options>`: Object to override global options just for the given window. It does a shallow merge.
 
 	@default () => true
 	@example
 	```
 	import debug from 'electron-debug';
+
 	debug({
-		windowSelector: (window) => window.title !== 'Debug tools',
+		windowSelector: window => window.title !== 'Debug tools',
 	});
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,13 +27,24 @@ export type Options = {
 	| 'detach';
 
 	/**
-	Allows to select windows to apply the debug options to.
-	Accepts a function to filter each window and returns:
-	- `true` to apply the given options
-	- `false` to skip the window (not apply debug)
-	- `Options` to override the global options
+	Specify customized options for each window.
+
+	@param window Window to apply the filter or new options to
+	@returns
+	- `true`: To enable `debug` with the global options for the given `window`.
+  - `false`: Disable `debug` for the given `window` (same as returning `{ isEnabled: false }`).
+  - `Partial<Options>`: Object to extend and/or override the global options just for the given `window`.
 
 	@default `() => true`
+
+	@example
+	```
+	import debug from 'electron-debug';
+
+	debug({
+	  windowSelector: (window) => window.title !== 'Debug tools',
+	});
+	```
 	*/
 	windowSelector?: (window: Readonly<BrowserWindow>) => boolean | Partial<Options>;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,14 +29,15 @@ export type Options = {
 	/**
 	Specify customized options for each window.
 
-	The accepted function receives the window to apply the filter or new options to.
-	It must return one of these values:
+	The given function receives the window to apply the filter or new options to.
 
+	It must return one of these values:
 	- `true`: To enable debug with the global options for the given window.
 	- `false`: Disable debug for the given window (same as returning `{isEnabled: false}`).
 	- `Partial<Options>`: Object to override global options just for the given window. It does a shallow merge.
 
 	@default () => true
+
 	@example
 	```
 	import debug from 'electron-debug';

--- a/index.js
+++ b/index.js
@@ -37,24 +37,22 @@ function getOptionsForWindow(win, options) {
 			: {...options, ...newOptions});
 }
 
-function registerAccelerators(win = BrowserWindow.getFocusedWindow()) {
-	(async () => {
-		await app.whenReady();
+async function registerAccelerators(win = BrowserWindow.getFocusedWindow()) {
+	await app.whenReady();
 
-		if (win) {
-			localShortcut.register(win, 'CommandOrControl+Shift+C', inspectElements);
-			localShortcut.register(win, isMacOS ? 'Command+Alt+I' : 'Control+Shift+I', devTools);
-			localShortcut.register(win, 'F12', devTools);
-			localShortcut.register(win, 'CommandOrControl+R', refresh);
-			localShortcut.register(win, 'F5', refresh);
-		} else {
-			localShortcut.register('CommandOrControl+Shift+C', inspectElements);
-			localShortcut.register(isMacOS ? 'Command+Alt+I' : 'Control+Shift+I', devTools);
-			localShortcut.register('F12', devTools);
-			localShortcut.register('CommandOrControl+R', refresh);
-			localShortcut.register('F5', refresh);
-		}
-	})();
+	if (win) {
+		localShortcut.register(win, 'CommandOrControl+Shift+C', inspectElements);
+		localShortcut.register(win, isMacOS ? 'Command+Alt+I' : 'Control+Shift+I', devTools);
+		localShortcut.register(win, 'F12', devTools);
+		localShortcut.register(win, 'CommandOrControl+R', refresh);
+		localShortcut.register(win, 'F5', refresh);
+	} else {
+		localShortcut.register('CommandOrControl+Shift+C', inspectElements);
+		localShortcut.register(isMacOS ? 'Command+Alt+I' : 'Control+Shift+I', devTools);
+		localShortcut.register('F12', devTools);
+		localShortcut.register('CommandOrControl+R', refresh);
+		localShortcut.register('F5', refresh);
+	}
 }
 
 // eslint-disable-next-line unicorn/prevent-abbreviations

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ Default: `() => true` (Use the global options for every window).
 
 ##### window
 
-Window to apply the filter or new options to
+Window to apply the filter or new options to.
 
 ##### Return value
 

--- a/readme.md
+++ b/readme.md
@@ -125,8 +125,8 @@ Window to apply the filter or new options to.
 ##### Return value
 
 - `true`: To enable `debug` with the global options for the given `window`.
-- `false`: Disable `debug` for the given `window` (same as returning `{ isEnabled: false }`).
-- `Partial<Options>`: Object to extend and/or override the global options just for the given `window`.
+- `false`: Disable `debug` for the given `window` (same as returning `{isEnabled: false}`).
+- `Partial<Options>`: Object to override global options just for the given window. It does a shallow merge.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,20 @@ Open DevTools for the specified `BrowserWindow` instance or the focused one.
 Type: `BrowserWindow`\
 Default: The focused `BrowserWindow`
 
+### windowSelector(filter)
+
+Allows to specify customized options for each window.
+
+#### filter
+
+Type: `(window: BrowserWindow) => boolean | Partial<Options>`\
+Default: `() => true` (Use the global options for every window).
+
+It can return:
+- `true`: Means `debug` is enabled for every window with the global options
+- `false`: Disable `debug` for the given window (maintain the global options for the rest)
+- `Partial<Options>`: Object to override the global options just for the given window
+
 ## Related
 
 - [electron-util](https://github.com/sindresorhus/electron-util) - Useful utilities for developing Electron apps and modules

--- a/readme.md
+++ b/readme.md
@@ -111,17 +111,22 @@ Default: The focused `BrowserWindow`
 
 ### windowSelector(filter)
 
-Allows to specify customized options for each window.
+Specify customized options for each window.
 
 #### filter
 
 Type: `(window: BrowserWindow) => boolean | Partial<Options>`\
 Default: `() => true` (Use the global options for every window).
 
-It can return:
-- `true`: Means `debug` is enabled for every window with the global options
-- `false`: Disable `debug` for the given window (maintain the global options for the rest)
-- `Partial<Options>`: Object to override the global options just for the given window
+##### window
+
+Window to apply the filter or new options to
+
+##### Return value
+
+- `true`: To enable `debug` with the global options for the given `window`.
+- `false`: Disable `debug` for the given `window` (same as returning `{ isEnabled: false }`).
+- `Partial<Options>`: Object to extend and/or override the global options just for the given `window`.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -124,8 +124,8 @@ Window to apply the filter or new options to.
 
 ##### Return value
 
-- `true`: To enable `debug` with the global options for the given `window`.
-- `false`: Disable `debug` for the given `window` (same as returning `{isEnabled: false}`).
+- `true`: To enable debug with the global options for the given window.
+- `false`: Disable debug for the given window (same as returning `{isEnabled: false}`).
 - `Partial<Options>`: Object to override global options just for the given window. It does a shallow merge.
 
 ## Related


### PR DESCRIPTION
It provides an implementation for #90 

It's a simple feature, but to handle every case it makes the code a bit complex.
- Providing the filter (`windowSelector`) the decision of applying 1. accelerators and 2. showing devTools, needs to be delayed until the "final options" are provided, as now they can be customized for each window
- The options used to open the devtools now it's a map, to allow different options for each window
- If the new (optional) filter is not provided, everything keeps working as before

Also, this PR tries also to refactor and reuse code as much as possible (therefore the new utility functions)